### PR TITLE
Implement actual operations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - db/schema.rb
+  TargetRubyVersion: 2.4
 
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
- gem "rspec"
+gem "rspec"

--- a/README.md
+++ b/README.md
@@ -15,3 +15,36 @@ The game plan to start with is to model the calculator's number input with a
 stack (at least to start out). When it hits an operator it'll pop some values
 off of the stack, perform an arithmatic operation with them, and then put the
 result back onto the stack.
+
+# Operations
+
+A key insight about the basic arithmatic operations is that they all take two
+parameters, and they all have an "identity" operand (in the case of addition
+and subtraction this is 0, in the case of multiplication and division it is 1).
+I made a base Operation class to handle the things that all operatoins have in
+common, which makes the Operations quite readable.
+
+# Adding a New Operation
+
+When I sat down to write this one thing I wanted to at least think about was
+what directions I would *expect* this code to expand. The most obvious two ways
+were: non-CLI interfaces and additional operators. It's pretty straightforward
+to add a new operation, as long as it can be done with two operands. It has to:
+
+1) Be implemented as a class inheriting from `Operation`
+2) Have a symbol added in the `OPERATORS` constant in `lib/calculator.rb`
+3) Have a corresponding key/value pair in the `OPERATIONS` constant in
+`lib/calculator/rb`
+
+The class has to implement `#perform` and `#identity`. Good operators to add
+would be things like: `**` (exponent), perhaps `log`, or `c` (combinatorial).
+
+I *think* you could have a pretty good pattern for operations that take
+more or fewer operands by implementing something like an `.arity` method for
+each operation, so that the `Calculator` class would know how many values need
+to be `pop`ed to run the operation. I haven't implemented this but in theory it
+seems straightforward (famous last words).
+
+# Adding a New Interface
+
+[TODO: Fill this out once I've actually added a single UI 😂]

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,1 +1,1 @@
-bundle exec rspec
+bundle exec rspec "$@"

--- a/division.rb
+++ b/division.rb
@@ -1,0 +1,13 @@
+require "operation"
+
+class Division
+  def perform
+    a / b
+  end
+
+  private
+
+  def identity
+    1
+  end
+end

--- a/lib/addition.rb
+++ b/lib/addition.rb
@@ -1,0 +1,13 @@
+require "operation"
+
+class Addition < Operation
+  def perform
+    a + b
+  end
+
+  private
+
+  def identity
+    0
+  end
+end

--- a/lib/calculator.rb
+++ b/lib/calculator.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "addition"
+require "division"
+require "multiplication"
+require "no_output"
+require "subtraction"
+
+class Calculator
+  attr_reader :output
+  NO_OUTPUT = NoOutput.new
+
+  OPERATORS = %w(+ - * /).freeze
+  OPERATIONS = {
+    "*" => Multiplication,
+    "+" => Addition,
+    "-" => Subtraction,
+    "/" => Division,
+  }.freeze
+
+  def initialize
+    @operands = []
+    @output = NO_OUTPUT
+  end
+
+  def input(input = "")
+    inputs = input.to_s.strip.split(/\s/)
+    inputs.each do |single_input|
+      @output = NO_OUTPUT
+
+      if single_input.match?(/\A$/)
+        # we might want to consider adding a replay functionality where we
+        # repeat the last operation with the current stack here.
+        next
+      elsif single_input =~ /(-?\d)/
+        @operands.push($1.to_i)
+      elsif OPERATORS.include?(single_input)
+        handle_operator(single_input)
+      else
+        raise "Unrecognized input: #{single_input.inspect}"
+      end
+    end
+    self
+  end
+
+  def handle_operator(operator)
+    if @operands.empty?
+      @output = NO_OUTPUT
+    else
+      result = OPERATIONS[operator].new(@operands.pop(2)).perform
+      @operands.push(result)
+      @output = result
+    end
+  end
+end

--- a/lib/division.rb
+++ b/lib/division.rb
@@ -1,0 +1,11 @@
+require "operation"
+
+class Division < Operation
+  def perform
+    a / b
+  end
+
+  def identity
+    1
+  end
+end

--- a/lib/multiplication.rb
+++ b/lib/multiplication.rb
@@ -1,0 +1,13 @@
+require "operation"
+
+class Multiplication < Operation
+  def perform
+    a * b
+  end
+
+  private
+
+  def identity
+    1
+  end
+end

--- a/lib/no_output.rb
+++ b/lib/no_output.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NoOutput
+  def to_s
+    ""
+  end
+end

--- a/lib/operation.rb
+++ b/lib/operation.rb
@@ -1,0 +1,24 @@
+class NoOperandsProvided < StandardError; end
+
+class Operation
+  def initialize(operands)
+    @a = operands.shift || no_operands_provided
+    @b = operands.shift || identity
+  end
+
+  def perform
+    raise NotImplementedError
+  end
+
+  def no_operands_provided
+    raise NoOperandsProvided
+  end
+
+  private
+
+  attr_reader :a, :b
+
+  def identity
+    raise NotImplementedError
+  end
+end

--- a/lib/subtraction.rb
+++ b/lib/subtraction.rb
@@ -1,0 +1,13 @@
+require "operation"
+
+class Subtraction < Operation
+  def perform
+    a - b
+  end
+
+  private
+
+  def identity
+    0
+  end
+end

--- a/spec/addition_spec.rb
+++ b/spec/addition_spec.rb
@@ -1,0 +1,25 @@
+require "addition"
+
+describe Addition do
+  describe "#perform" do
+    context "with a single operand" do
+      it "is a noop" do
+        operands = [1]
+
+        adder = Addition.new(operands)
+
+        expect(adder.perform).to eq(1)
+      end
+    end
+
+    context "with multiple operands" do
+      it "adds them" do
+        operands = [2, 3]
+
+        adder = Addition.new(operands)
+
+        expect(adder.perform).to eq(5)
+      end
+    end
+  end
+end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -1,0 +1,36 @@
+require "calculator"
+
+describe "Calculator" do
+  describe ".input" do
+    it "can handle a blank input string" do
+      expect(run_input("")).to be_a(NoOutput)
+      expect(run_input("\n")).to be_a(NoOutput)
+      expect(run_input(" ")).to be_a(NoOutput)
+    end
+
+    it "can handle an integer as input" do
+      (0..9).each do |int|
+        expect(run_input(int)).to be_a(NoOutput)
+      end
+    end
+
+    it "treats integers after operators as a reset to the output" do
+      expect(run_input("1 3 + 1 ")).to be_a(NoOutput)
+    end
+
+    it "correctly calls the operation for only the last two inputs" do
+      calculator = Calculator.new
+
+      expect(calculator.input("5 1 3 +").output).to eq(4)
+      expect(calculator.input("+").output).to eq(9)
+    end
+
+    it "has no output when there is only an operator" do
+      expect(run_input("+")).to be_a(NoOutput)
+    end
+  end
+end
+
+def run_input(equation)
+  Calculator.new.input(equation).output
+end

--- a/spec/division_spec.rb
+++ b/spec/division_spec.rb
@@ -1,0 +1,25 @@
+require "division"
+
+describe Division do
+  describe "#perform" do
+    context "with a single operand" do
+      it "is a noop" do
+        operands = [1]
+
+        divider = Division.new(operands)
+
+        expect(divider.perform).to eq(1)
+      end
+    end
+
+    context "with multiple operands" do
+      it "subctracts the last operand from the second to last" do
+        operands = [10, 5]
+
+        divider = Division.new(operands)
+
+        expect(divider.perform).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/multiplication_spec.rb
+++ b/spec/multiplication_spec.rb
@@ -1,0 +1,25 @@
+require "multiplication"
+
+describe Multiplication do
+  describe "#perform" do
+    context "with a single operand" do
+      it "is a noop" do
+        operands = [1]
+
+        multiplier = Multiplication.new(operands)
+
+        expect(multiplier.perform).to eq(1)
+      end
+    end
+
+    context "with multiple operands" do
+      it "subctracts the last operand from the second to last" do
+        operands = [2, 5]
+
+        multiplier = Multiplication.new(operands)
+
+        expect(multiplier.perform).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -1,0 +1,37 @@
+require "operation"
+
+class SimpleOperation < Operation
+  def perform
+    [a, b]
+  end
+
+  def identity
+    :identity
+  end
+end
+
+describe Operation do
+  describe ".new" do
+    context "when there are multiple operands" do
+      it "assigns the first to a and the second to b" do
+        operands = %i(a b)
+
+        expect(SimpleOperation.new(operands).perform).to eq(%i(a b))
+      end
+    end
+
+    context "when there is only one operand" do
+      it "assigns the first to a and identity to b" do
+        operands = %i(a)
+
+        expect(SimpleOperation.new(operands).perform).to eq(%i(a identity))
+      end
+    end
+
+    context "when there are no operands" do
+      it "raises a related error" do
+        expect { SimpleOperation.new([]) }.to raise_error(NoOperandsProvided)
+      end
+    end
+  end
+end

--- a/spec/subtraction_spec.rb
+++ b/spec/subtraction_spec.rb
@@ -1,0 +1,25 @@
+require "subtraction"
+
+describe Subtraction do
+  describe "#perform" do
+    context "with a single operand" do
+      it "is a noop" do
+        operands = [1]
+
+        subtracter = Subtraction.new(operands)
+
+        expect(subtracter.perform).to eq(1)
+      end
+    end
+
+    context "with multiple operands" do
+      it "subctracts the last operand from the second to last" do
+        operands = [2, 1]
+
+        subtracter = Subtraction.new(operands)
+
+        expect(subtracter.perform).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
At first I was going to keep addition, subtraction, division, and
multiplication as separate PR's/commits, but once I abstracted out the
Operation class they became so trivial as to not feel worth it.

---

Most of this has been added to the readme but here's a quick breakdown:

- Operation is a class that describes an interface that all of our
current mathematical operations implement. You hand them an array of
operands and they do their best to compute the output. One operand will
be computed with an `identity` operand. Zero operands is an error. Our
calculator basically ignores operations with no operands, so this
shouldn't come up, but I'm leaving the possible exception there because
I think it could be helpfully descriptive if something ever goes wrong
with a change to `Calculator`.
- Reading through the actual operations should be super obvious at this
point.

Other miscellaneous changes:

- The default gemfile has some non-rubocop conforming stuff so I edited
  that to quiet down rubocop.
- Without a target version rubocop won't acknowledge the
  frozen_string_literal pragma and kept complaining about mutable
  strings as constants
- I forgot to pass arguments through to the `rspec` binstub :whoops:

Next Steps:

- Now is probably a good time to implement an actual CLI interface to
play with this thing