### PR TITLE
Jm repeat last operation

### DIFF
--- a/bin/calculator
+++ b/bin/calculator
@@ -5,12 +5,23 @@ $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 require "calculator"
 require "readline"
 
+QUIT_COMMANDS = ["q"].freeze
+RESET_COMMANDS = ["reset", "r"].freeze
+
 calculator = Calculator.new
 
+puts "Enter 'q' to exit"
+
 while command = Readline.readline("> ", true)
-  if command == "q"
+  if QUIT_COMMANDS.include?(command)
     exit 0
+  elsif RESET_COMMANDS.include?(command)
+    calculator = Calculator.new
   else
-    puts calculator.input(command).output
+    begin
+      puts calculator.input(command).output
+    rescue UnrecognizedCommand => error
+      puts error.message
+    end
   end
 end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -2,10 +2,14 @@ require "calculator"
 
 describe "Calculator" do
   describe ".input" do
-    it "can handle a blank input string" do
-      expect(run_input("")).to be_a(NoOutput)
-      expect(run_input("\n")).to be_a(NoOutput)
-      expect(run_input(" ")).to be_a(NoOutput)
+    it "treats a blank string as a repeat command" do
+      calculator = Calculator.new
+
+      expect(calculator.input("").output).to be_a(NoOutput)
+      calculator.input("1 1 1")
+      calculator.input("+")
+      calculator.input("\n")
+      expect(calculator.output).to eq(3.0)
     end
 
     it "can handle an integer as input" do


### PR DESCRIPTION
Changes
---

- Allow a blank input to repeat the last operation
  * So if there are still multiple operands available we will re-run the
last command if a blank input is given. I just think this is neat. It
allows you to do things like put in a long string of numbers followed by
a plus sign and just hit enter a bunch of times and get their sum.
- Handle errors better on the CLI
  * I kept typing `exit`, which worked because the exception brought down the CLI 😂 , but I wanted better handling here. Now we print out a reminder of the *proper* way to get out of the program and gracefully recover from invalid input